### PR TITLE
depend on community.vmware

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -2,3 +2,4 @@ collections:
   - name: https://github.com/pb82/vmware.vmware.git
     type: git
     version: main
+  - name: community.vmware


### PR DESCRIPTION
Fixes `ERROR! couldn't resolve module/action 'community.vmware.vmware_guest'. This often indicates a misspelling, missing collection, or incorrect module path.` when trying to launch the job.